### PR TITLE
Cast error in RegularLevel and Heap

### DIFF
--- a/src/com/watabou/pixeldungeon/items/Heap.java
+++ b/src/com/watabou/pixeldungeon/items/Heap.java
@@ -324,7 +324,7 @@ public class Heap implements Bundlable {
 	public void restoreFromBundle( Bundle bundle ) {
 		pos = bundle.getInt( POS );
 		type = Type.valueOf( bundle.getString( TYPE ) );
-		items = new LinkedList<Item>( (Collection<? extends Item>) bundle.getCollection( ITEMS ) ); 
+		items = new LinkedList<Item>( (Collection<Item>) ((Collection<?>) bundle.getCollection( ITEMS )) ); 
 	}
 
 	@Override

--- a/src/com/watabou/pixeldungeon/levels/RegularLevel.java
+++ b/src/com/watabou/pixeldungeon/levels/RegularLevel.java
@@ -682,7 +682,7 @@ public abstract class RegularLevel extends Level {
 	public void restoreFromBundle( Bundle bundle ) {
 		super.restoreFromBundle( bundle );
 
-		rooms = new HashSet<Room>( (Collection<? extends Room>) bundle.getCollection( "rooms" ) );
+		rooms = new HashSet<Room>( (Collection<Room>) ((Collection<?>) bundle.getCollection( "rooms" )) );
 		for (Room r : rooms) {
 			if (r.type == Type.WEAK_FLOOR) {
 				weakFloorCreated = true;


### PR DESCRIPTION
Hi !

First of all, thanks for releasing the source code of your amazing game !

Unfortunately, the code does not compile as is on my station (java 6). It fails with two similar casting errors, in Heap.java and RegularLevel.java. I looked it up, and the statement

 (Collection<? extends Item>) bundle.getCollection(ITEM)

seems bogus to me: Item implements Bundlable, not the opposite. The error is very similar in RegularLevel.java.

I tried to fix it but I'm not a Java Guru, so feel free to reject my pull request and provide a better version of this fix. :]
