### PR TITLE
Updated the cast error fix by Lertsenem for 1.7.2a

### DIFF
--- a/src/com/watabou/pixeldungeon/items/Heap.java
+++ b/src/com/watabou/pixeldungeon/items/Heap.java
@@ -325,7 +325,7 @@ public class Heap implements Bundlable {
 	public void restoreFromBundle( Bundle bundle ) {
 		pos = bundle.getInt( POS );
 		type = Type.valueOf( bundle.getString( TYPE ) );
-		items = new LinkedList<Item>( (Collection<? extends Item>) bundle.getCollection( ITEMS ) ); 
+		items = new LinkedList<Item>( (Collection<Item>) ((Collection<?>) bundle.getCollection( ITEMS )) ); 
 	}
 
 	@Override

--- a/src/com/watabou/pixeldungeon/levels/RegularLevel.java
+++ b/src/com/watabou/pixeldungeon/levels/RegularLevel.java
@@ -684,7 +684,7 @@ public abstract class RegularLevel extends Level {
 	public void restoreFromBundle( Bundle bundle ) {
 		super.restoreFromBundle( bundle );
 		
-		rooms = new HashSet<Room>( (Collection<? extends Room>) bundle.getCollection( "rooms" ) );
+		rooms = new HashSet<Room>( (Collection<Room>) ((Collection<?>) bundle.getCollection( "rooms" )) );
 		for (Room r : rooms) {
 			if (r.type == Type.WEAK_FLOOR) {
 				weakFloorCreated = true;


### PR DESCRIPTION
This is the same change as in the [pull request](https://github.com/watabou/pixel-dungeon/pull/1) by @Lertsenem for **1.7.1c**, except updated to merge against **1.7.2a**. Without it, **pixel-dungeon** can't be compiled in some environments, such as with (at least) **ant** and **openjdk7**/**8**.