### PR TITLE
Updated the cast error fix by Lertsenem for 1.7.5a

### DIFF
--- a/src/com/watabou/pixeldungeon/actors/mobs/Mimic.java
+++ b/src/com/watabou/pixeldungeon/actors/mobs/Mimic.java
@@ -64,7 +64,7 @@ public class Mimic extends Mob {
 	@Override
 	public void restoreFromBundle( Bundle bundle ) {
 		super.restoreFromBundle( bundle );
-		items = new ArrayList<Item>( (Collection<? extends Item>) bundle.getCollection( ITEMS ) ); 
+		items = new ArrayList<Item>( (Collection<Item>) ((Collection<?>) bundle.getCollection( ITEMS )) ); 
 		adjustStats( bundle.getInt( LEVEL ) );
 	}
 	

--- a/src/com/watabou/pixeldungeon/items/Heap.java
+++ b/src/com/watabou/pixeldungeon/items/Heap.java
@@ -360,7 +360,7 @@ public class Heap implements Bundlable {
 	public void restoreFromBundle( Bundle bundle ) {
 		pos = bundle.getInt( POS );
 		type = Type.valueOf( bundle.getString( TYPE ) );
-		items = new LinkedList<Item>( (Collection<? extends Item>) bundle.getCollection( ITEMS ) ); 
+		items = new LinkedList<Item>( (Collection<Item>) ((Collection<?>) bundle.getCollection( ITEMS )) ); 
 	}
 
 	@Override

--- a/src/com/watabou/pixeldungeon/levels/RegularLevel.java
+++ b/src/com/watabou/pixeldungeon/levels/RegularLevel.java
@@ -682,7 +682,7 @@ public abstract class RegularLevel extends Level {
 	public void restoreFromBundle( Bundle bundle ) {
 		super.restoreFromBundle( bundle );
 		
-		rooms = new HashSet<Room>( (Collection<? extends Room>) bundle.getCollection( "rooms" ) );
+		rooms = new HashSet<Room>( (Collection<Room>) ((Collection<?>) bundle.getCollection( "rooms" )) );
 		for (Room r : rooms) {
 			if (r.type == Type.WEAK_FLOOR) {
 				weakFloorCreated = true;


### PR DESCRIPTION
This is the same fix as in the pull request by @Lertsenem for 1.7.1c and my own based on his for 1.7.2a. Without it, pixel-dungeon can't be compiled in some environments, such as with (at least) ant and openjdk7/8.
