### PR TITLE
Add missing casts and remove FloatMath methods calls

### DIFF
--- a/src/com/watabou/pixeldungeon/actors/mobs/Mimic.java
+++ b/src/com/watabou/pixeldungeon/actors/mobs/Mimic.java
@@ -64,7 +64,7 @@ public class Mimic extends Mob {
 	@Override
 	public void restoreFromBundle( Bundle bundle ) {
 		super.restoreFromBundle( bundle );
-		items = new ArrayList<Item>( (Collection<? extends Item>) bundle.getCollection( ITEMS ) ); 
+		items = new ArrayList<Item>( (Collection<? extends Item>)(Object) bundle.getCollection( ITEMS ) );
 		adjustStats( bundle.getInt( LEVEL ) );
 	}
 	

--- a/src/com/watabou/pixeldungeon/effects/Flare.java
+++ b/src/com/watabou/pixeldungeon/effects/Flare.java
@@ -87,13 +87,13 @@ public class Flare extends Visual {
 		for (int i=0; i < nRays; i++) {
 			
 			float a = i * 3.1415926f * 2 / nRays;
-			v[0] = FloatMath.cos( a ) * radius;
-			v[1] = FloatMath.sin( a ) * radius;
+			v[0] = (float)Math.cos( a ) * radius;
+			v[1] = (float)Math.sin( a ) * radius;
 			vertices.put( v );
 			
 			a += 3.1415926f * 2 / nRays / 2;
-			v[0] = FloatMath.cos( a ) * radius;
-			v[1] = FloatMath.sin( a ) * radius;
+			v[0] = (float)Math.cos( a ) * radius;
+			v[1] = (float)Math.sin( a ) * radius;
 			vertices.put( v );
 			
 			indices.put( (short)0 );

--- a/src/com/watabou/pixeldungeon/effects/Speck.java
+++ b/src/com/watabou/pixeldungeon/effects/Speck.java
@@ -372,9 +372,9 @@ public class Speck extends Image {
 				break;
 				
 			case CHANGE:
-				am = (float)FloatMath.sqrt( (p < 0.5f ? p : 1 - p) * 2);
+				am = (float) Math.sqrt( (p < 0.5f ? p : 1 - p) * 2);
 				scale.y = (1 + p) * 0.5f;
-				scale.x = scale.y * FloatMath.cos( left * 15 );
+				scale.x = scale.y * (float) Math.cos( left * 15 );
 				break;
 				
 			case HEART:
@@ -401,7 +401,7 @@ public class Speck extends Image {
 				break;
 				
 			case COIN:
-				scale.x = FloatMath.cos( left * 5 );
+				scale.x = (float) Math.cos( left * 5 );
 				rm = gm = bm = (Math.abs( scale.x ) + 1) * 0.5f;
 				am = p < 0.9f ? 1 : (1 - p) * 10;
 				break;

--- a/src/com/watabou/pixeldungeon/items/Heap.java
+++ b/src/com/watabou/pixeldungeon/items/Heap.java
@@ -370,7 +370,7 @@ public class Heap implements Bundlable {
 	public void restoreFromBundle( Bundle bundle ) {
 		pos = bundle.getInt( POS );
 		type = Type.valueOf( bundle.getString( TYPE ) );
-		items = new LinkedList<Item>( (Collection<? extends Item>) bundle.getCollection( ITEMS ) ); 
+		items = new LinkedList<Item>( (Collection<? extends Item>)(Object) bundle.getCollection( ITEMS ) );
 	}
 
 	@Override

--- a/src/com/watabou/pixeldungeon/levels/RegularLevel.java
+++ b/src/com/watabou/pixeldungeon/levels/RegularLevel.java
@@ -679,7 +679,7 @@ public abstract class RegularLevel extends Level {
 	public void restoreFromBundle( Bundle bundle ) {
 		super.restoreFromBundle( bundle );
 		
-		rooms = new HashSet<Room>( (Collection<? extends Room>) bundle.getCollection( "rooms" ) );
+		rooms = new HashSet<Room>( (Collection<? extends Room>)(Object) bundle.getCollection( "rooms" ) );
 		for (Room r : rooms) {
 			if (r.type == Type.WEAK_FLOOR) {
 				weakFloorCreated = true;


### PR DESCRIPTION
This will remove compile errors on modern javac.

Note: android.util.FloatMath class was deprecated and all its methods was removed in API version 23 and above.

Also adding (Object) cast before `bundle.getCollection()` call will supress `Incompatible types` error in Android Studio. 